### PR TITLE
Add Default Plugin Options to Getting Started Page

### DIFF
--- a/source/docs/getting-started.md
+++ b/source/docs/getting-started.md
@@ -36,7 +36,54 @@ Just in case you need a suggestion you can use [lazy](https://github.com/folke/l
 }
 ```
 
-> Tip: you can check the default options in the package, a powerful way of customizing and extending it is setting providers as Laravel does.
+Default plugin options:
+```lua
+opts = {
+  lsp_server = "phpactor",
+  features = {
+    route_info = {
+      enable = true,
+      view = "top",
+    },
+    model_info = {
+      enable = true,
+    },
+    override = {
+      enable = true,
+    },
+    pickers = {
+      enable = true,
+      provider = 'telescope',
+    },
+  },
+  ui = require("laravel.options.ui"),
+  commands_options = require("laravel.options.command_options"),
+  environments = require("laravel.options.environments"),
+  user_commands = require("laravel.options.user_commands"),
+  resources = require("laravel.options.resources"),
+  providers = {
+    require("laravel.providers.laravel_provider"),
+    require("laravel.providers.repositories_provider"),
+    require("laravel.providers.override_provider"),
+    require("laravel.providers.completion_provider"),
+    require("laravel.providers.route_info_provider"),
+    require("laravel.providers.tinker_provider"),
+    require("laravel.providers.telescope_provider"),
+    require("laravel.providers.fzf_lua_provider"),
+    require("laravel.providers.ui_select_provider"),
+    require("laravel.providers.user_command_provider"),
+    require("laravel.providers.status_provider"),
+    require("laravel.providers.diagnostics_provider"),
+    require("laravel.providers.model_info_provider"),
+    require("laravel.providers.composer_info_provider"),
+    require("laravel.providers.history_provider"),
+  },
+  user_providers = {}, -- Custom providers, see below
+}
+```
+
+
+> Tip: A powerful way of customizing and extending it is setting providers as Laravel does.
 
 ---
 


### PR DESCRIPTION
I think it would be useful to add the default options to the docs. Today I couldn't figure out from the docs how to change the picker, 
and I didn't think about looking at the default options in the source code.
I often see plugins that include them in the README (which I would I advice to improve in the main repo, since it would be nice to get the important information, such as plugin installation and providers, just by looking at the readme).